### PR TITLE
Django2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
   - DJANGO="Django>=1.11,<1.12"
+  - DJANGO="Django>=2.2,<2.3"
 
 notifications:
     irc: "irc.freenode.org#haystack"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 before_install:
@@ -15,9 +13,6 @@ script:
   - coverage run --branch --source=celery_haystack `which django-admin.py` test celery_haystack
   - coverage report --omit=celery_haystack/test*
 env:
-  - DJANGO="Django>=1.8,<1.9"
-  - DJANGO="Django>=1.9,<1.10"
-  - DJANGO="Django>=1.10,<1.11"
   - DJANGO="Django>=1.11,<1.12"
   - DJANGO="Django>=2.2,<2.3"
 


### PR DESCRIPTION
Update the travis builds for django 1.11 and 2.2.  Drops support for prior versions of Django and unsupported versions of Python.